### PR TITLE
apply licensing header to all source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@
 
 <hr />
 
-<div style="padding: 15px; border: 1px solid #ffeeba; border-radius: 4px; color: #856404; background-color: #fff3cd; margin-bottom: 20px;">
-  <strong>Note:</strong> This project is still under construction. Features may be incomplete or subject to change.
-</div>
-
-<hr />
-
 ## Target Architecture
 
 `propeller` is designed to seamlessly integrate with a specific application deployment architecture commonly used in modern environments:
@@ -268,3 +262,9 @@ Please [create an issue](https://github.com/postfinance/propeller/issues/new), o
 **Welcome to the bottom of the README club! Since you've come this far, go ahead and smash that like and subsc… er, uh, give this project a ⭐️ on GitHub! 🙏🏼**
 
 <small>Hats off to [@pmcelhaney](https://github.com/pmcelhaney/counterfact) for this amazing line that we couldn't resist stealing.. er, uh, which inspired us. Hope you don't mind 😏</small>
+
+## License
+
+This project is licensed under the MIT License. See the [`LICENSE` file](LICENSE) for details.
+
+Copyright (c) 2024 PostFinance AG

--- a/src/argo_cd.rs
+++ b/src/argo_cd.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use log::{debug, info, warn};
 use reqwest::header::CONTENT_TYPE;
 use reqwest::{Client, RequestBuilder};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use clap::{Parser, Subcommand};
 
 /// propeller - Automated database secret rotation.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use log::debug;
 use serde::Deserialize;
 use std::{fs::File, io::Read, path::PathBuf};

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use postgres::{Client, NoTls};
 
 use crate::config::{Config, PostgresConfig};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use clap::Parser;
 use env_logger::{Env, DEFAULT_WRITE_STYLE_ENV};
 
@@ -41,4 +46,62 @@ fn init_logger() {
         .write_style_or("PROPELLER_LOG_STYLE", DEFAULT_WRITE_STYLE_ENV);
 
     env_logger::init_from_env(env);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{read_dir, read_to_string};
+    use std::path::Path;
+
+    #[test]
+    fn test_license_headers() {
+        let expected_header = r#"// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+"#;
+
+        let directories = ["src", "tests"];
+
+        for dir in &directories {
+            verify_all_files_in_directory_start_with_license_header(dir, expected_header);
+        }
+    }
+
+    fn verify_all_files_in_directory_start_with_license_header(dir: &str, expected_header: &str) {
+        let paths = read_dir(dir).unwrap();
+
+        for path in paths {
+            let path = path.unwrap().path();
+            if should_process_path(&path) {
+                if path.is_dir() {
+                    verify_all_files_in_directory_start_with_license_header(
+                        path.to_str().unwrap(),
+                        expected_header,
+                    );
+                } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+                    verify_file_starts_with_license_header(&path, expected_header);
+                }
+            }
+        }
+    }
+
+    fn should_process_path(path: &Path) -> bool {
+        let path_str = path.to_str().unwrap();
+        if path_str.starts_with("tests/utilities") {
+            path_str == "tests/utilities/src" || path_str.starts_with("tests/utilities/src/")
+        } else {
+            true
+        }
+    }
+
+    fn verify_file_starts_with_license_header(path: &Path, expected_header: &str) {
+        let contents = read_to_string(path).unwrap();
+        assert!(
+            contents.starts_with(expected_header),
+            "File {} does not start with the expected license header",
+            path.display()
+        );
+    }
 }

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use log::trace;
 use rand::distr::Alphanumeric;
 use rand::{thread_rng, Rng};

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use std::env;
 
 use log::{debug, info};

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use log::{debug, error, info, trace};
 
 use crate::argo_cd::ArgoCD;

--- a/tests/init_vault.rs
+++ b/tests/init_vault.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use std::process::{Command, Stdio};
 
 use assert_cmd::prelude::*;

--- a/tests/rotate.rs
+++ b/tests/rotate.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use assert_cmd::prelude::*;
 use ntest::timeout;
 use postgres::NoTls;

--- a/tests/utilities/src/lib.rs
+++ b/tests/utilities/src/lib.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 PostFinance AG
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 use futures::StreamExt;


### PR DESCRIPTION
all rust files should indicate that they're licensed under the terms of the MIT license.